### PR TITLE
Удаляет вызов функции ini_set, переопределяющий объём памяти

### DIFF
--- a/bg-hlnames.php
+++ b/bg-hlnames.php
@@ -58,9 +58,6 @@ include_once('includes/settings.php' );
 // Задаем начальные значения параметров
 bg_hlnames_add_options ();
 
-ini_set('memory_limit', '256M');
-
-
 // Проверяем текущую версию плагина и обновляем файл данных
 function bg_hlnames_update_datefile() {
 	if ( version_compare( get_option('bg_hlnames_version'), BG_HLNAMES_VERSION, '<' ) ) {


### PR DESCRIPTION
Добрый день!

Не стоит вызывать функции ini_set внутри плагинов для переопределения объёма выделенной памяти, потому что это негативно сказывается на работе сайта в целом.

Мой коммит убирает это переопределение.